### PR TITLE
Make gsetting.py compatible with Python 3

### DIFF
--- a/gsetting.py
+++ b/gsetting.py
@@ -102,11 +102,11 @@ def main():
     if changed and not module.check_mode:
         _set_value(schemadir, user, key, value)
 
-    print json.dumps({
+    print(json.dumps({
         'changed': changed,
         'key': key,
         'value': value,
         'old_value': old_value,
-    })
+    }))
 
 main()


### PR DESCRIPTION
This (parentheses around print) is the only change reported by the 2to3 tool.