### PR TITLE
Allow non-integer parts of GNOME version number

### DIFF
--- a/gsetting.py
+++ b/gsetting.py
@@ -18,9 +18,15 @@ def _split_key(full_key):
     single_key = key_array[-1]
     return (schema, single_key)
 
+def _maybe_int(val):
+    try:
+        return int(val)
+    except ValueError:
+        return 0
+
 def _get_gnome_version():
     try:
-        return tuple(map(int, (_check_output_strip(
+        return tuple(map(_maybe_int, (_check_output_strip(
             ['gnome-shell', '--version']).split(' ')[2].split('.'))))
     except FileNotFoundError:
         return None


### PR DESCRIPTION
`gnome-shell --version` may return, e.g., `42.beta`, so we can't
assume that all parts of the version number are integers. Change how
the version number is parsed so that non-integer components are
treated as 0.

Another option would be to use `packaging.version.parse` to parse the
version numbers rather than parsing them ourselves, but that would
introduce to this module a dependency on `packaging.version`, which
would probably be gratuitous.