### PR TITLE
Fix key in changed_settings & unchanged_settings

### DIFF
--- a/gsetting.py
+++ b/gsetting.py
@@ -182,7 +182,7 @@ def main():
 
     for setting, value in parsed_settings:
         old_value = _get_value(schemadir, user, setting, dbus_addr)
-        result = {'key': key, 'value': old_value}
+        result = {'key': '.'.join(setting.args), 'value': old_value}
         changed = old_value != value
         any_changed = any_changed or changed
 


### PR DESCRIPTION
Fixed "key" names in module result dict's "changed_settings" & "unchanged_settings"